### PR TITLE
[0.8.22] Use a dedicated socket for podDiscovery.

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -129,7 +129,13 @@ exports.start = function (params, cb) {
   if (params.ip) properties.netInfo.ip = params.ip;
 
   adapters.remote.start(function () {
-    var discoveryParams = {addr: params.discoveryAddr, port: params.discoveryPort, pods: params.podAddrs};
+    var discoveryParams = {
+      addr: params.discoveryAddr,
+      port: params.discoveryPort,
+      pods: params.podAddrs,
+      podDiscoveryPort: params.podDiscoveryPort
+    };
+
     discovery.start(discoveryParams, function () {
       started = true;
       locked = false;

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -40,6 +40,11 @@ var mcastSock = null;
 var localSock = null;
 
 /**
+ * @type {Socket}
+ */
+var podDiscoverySock = null;
+
+/**
  * @type {object}
  */
 var lastResearches = {};
@@ -54,6 +59,12 @@ var researchesLoops = {};
  * @type {object}
  */
 var localInfos = {};
+
+/**
+ * POD discovery socket infos
+ * @type {object}
+ */
+var podDiscoveryInfos = {};
 
 /**
  * Multicast/Broadcast discovery socket infos
@@ -72,8 +83,7 @@ var discoveryAddrs = null;
  * A pod is a group of containers collocated on se same multicast network
  * It can be a VM in public cloud or a datacenter in a multi datacenter
  * configuration.
- * @type {Array} Array of string with format http://192.168.0.1:2302 the list
- * must exclude the current POD address
+ * @type {Array} Array of string with format http://192.168.0.1:2302
  */
 var podAddrs = null;
 
@@ -92,20 +102,22 @@ exports.start = function (params, done) {
 
   localInfos.host = properties.netInfo.ip;
   localInfos.port = params.port || _.random(3000, 60000);
-  if (semver.gt(process.version, '0.12.0'))
-    localSock = dgram.createSocket({type:'udp4', reuseAddr: true});
-  else
-    localSock = dgram.createSocket('udp4');
+
+  localSock = createSocket();
   localSock.on('message', onMessage);
+
+  if (params.pods && params.podDiscoveryPort) {
+    podDiscoveryInfos.host = properties.netInfo.ip;
+    podDiscoveryInfos.port = params.podDiscoveryPort;
+    podDiscoverySock = createSocket();
+    podDiscoverySock.on('message', onMessage);
+  }
 
   if (params.addr) {
     var mcastAddr = url.parse(params.addr);
     mcastInfos.host = mcastAddr.hostname;
     mcastInfos.port = mcastAddr.port || 5555;
-    if (semver.gt(process.version, '0.12.0'))
-      mcastSock = dgram.createSocket({type:'udp4', reuseAddr: true});
-    else
-      mcastSock = dgram.createSocket('udp4');
+    mcastSock = createSocket();
     mcastSock.on('message', onMessage);
   }
 
@@ -114,6 +126,12 @@ exports.start = function (params, done) {
   } else {
     async.parallel([
       function (done) { localSock.bind(localInfos.port, localInfos.host, done); },
+      function (done) {
+        if (podDiscoverySock)
+          podDiscoverySock.bind(podDiscoveryInfos.port, podDiscoveryInfos.host, done);
+        else
+          done();
+      },
       function (done) { mcastSock.bind(mcastInfos.port, mcastInfos.host, done); }
     ], onStart);
   }
@@ -154,6 +172,11 @@ exports.stop = function (done) {
     localSock = null;
   }
 
+  if (podDiscoverySock) {
+    podDiscoverySock.close();
+    podDiscoverySock = null;
+  }
+
   if (mcastSock) {
     mcastSock.close();
     mcastSock = null;
@@ -183,6 +206,19 @@ exports.setDiscoveryAddrs = function (value) {
     discoveryAddrs = null;
   }
 };
+
+/**
+ * Create a udp4 socket
+ * @returns {dgram.Socket} the created socket
+ */
+function createSocket () {
+  if (semver.gt(process.version, '0.12.0')) {
+    return dgram.createSocket({type:'udp4', reuseAddr: true});
+  }
+  else {
+    return dgram.createSocket('udp4');
+  }
+}
 
 /**
  * Set PODS addresses
@@ -256,8 +292,8 @@ function search(aid) {
     localSock.send(msg, 0, msg.length, mcastInfos.port, mcastInfos.host);
     if (podAddrs) {
       _.forEach(podAddrs, function (container) {
-        logger.makeLog('trace', 'hub-55', 'RemoteSearch to ' + JSON.stringify(container) + ' : ' + JSON.stringify(remoteMsg));
-        localSock.send(remoteMsg, 0, remoteMsg.length, container.port, container.host);
+        logger.makeLog('trace', 'hub-55', 'RemoteSearch ' + aid + ' sent to ' + JSON.stringify(container));
+        podDiscoverySock.send(remoteMsg, 0, remoteMsg.length, container.port, container.host);
       });
     }
   } else if (discoveryAddrs) {
@@ -333,15 +369,6 @@ function encode(msg) {
     senderPort = new Buffer(2);
     senderPort.writeUInt16BE(msg.netInfo.port, 0);
     result = concatBuffers([type, from, vfrom, aid, senderHost, senderPort]);
-  } else if (msg.type === 'remoteSearch') {
-    type = new Buffer([0]);
-    from = new Buffer(msg.from, 'utf8');
-    vfrom = new Buffer(msg.vfrom, 'utf8');
-    aid = new Buffer(msg.aid, 'utf8');
-    senderHost = new Buffer(msg.netInfo.host, 'utf8');
-    senderPort = new Buffer(2);
-    senderPort.writeUInt16BE(msg.netInfo.port, 0);
-    result = concatBuffers([type, from, vfrom, aid, senderHost, senderPort]);
   } else if (msg.type === 'result') {
     type = new Buffer([1]);
     from = new Buffer(msg.from, 'utf8');
@@ -354,6 +381,15 @@ function encode(msg) {
     var port = new Buffer(2);
     port.writeUInt16BE(msg.netInfo.port, 0);
     result = concatBuffers([type, from, vfrom, to, aid, ip, pid, port]);
+  } else if (msg.type === 'remoteSearch') {
+    type = new Buffer([2]);
+    from = new Buffer(msg.from, 'utf8');
+    vfrom = new Buffer(msg.vfrom, 'utf8');
+    aid = new Buffer(msg.aid, 'utf8');
+    senderHost = new Buffer(msg.netInfo.host, 'utf8');
+    senderPort = new Buffer(2);
+    senderPort.writeUInt16BE(msg.netInfo.port, 0);
+    result = concatBuffers([type, from, vfrom, aid, senderHost, senderPort]);
   }
 
   return result;
@@ -370,16 +406,21 @@ function decode(buffer) {
   var type, from, vfrom, aid;
   var bufferComponents = splitBuffers(buffer);
   var idx = 0;
+  var encodedType = nextBuffer()[0];
 
-  if (bufferComponents.length === 6 && nextBuffer()[0] === 0) {
-    type = 'search';
+  if (bufferComponents.length === 6) {
+    if (encodedType === 0)
+      type = 'search';
+    if (encodedType === 2)
+      type = 'remoteSearch';
+
     from = nextBuffer().toString('utf8');
     vfrom = nextBuffer().toString('utf8');
     aid = nextBuffer().toString('utf8');
     var senderHost = nextBuffer().toString('utf8');
     var senderPort = nextBuffer().readUInt16BE(0);
     result = {type: type, from: from, vfrom: vfrom, aid: aid, netInfo: {host: senderHost, port: senderPort}};
-  } else if (bufferComponents.length === 8 && nextBuffer()[0] === 1) {
+  } else if (bufferComponents.length === 8 && encodedType === 1) {
     type = 'result';
     from = nextBuffer().toString('utf8');
     vfrom = nextBuffer().toString('utf8');

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -25,16 +25,28 @@ exports.startParams = {
   title: 'start parameters',
   description: 'start parameters',
   type: 'object',
-  properties: {
-    discoveryAddr: {type: 'string'},
-    discoveryPort: {type: 'number'},
-    ip: {type: 'string'},
-    podAddrs: {
-      type: ['array', 'undefined'],
-      items: {type: 'string'},
-      minItems: 1
+  oneOf: [
+    {
+      properties: {
+        discoveryAddr: {type: 'string'},
+        discoveryPort: {type: 'number'},
+        ip: {type: 'string'},
+      },
+      additionalProperties: false
+    },
+    {
+      properties: {
+        discoveryAddr: {type: 'string'},
+        ip: {type: 'string'},
+        podAddrs: {
+          type: ['array', 'undefined'],
+          items: {type: 'string'},
+          minItems: 1
+        },
+        podDiscoveryPort: {type: 'number'}
+      },
+      required: ['discoveryAddr', 'ip', 'podAddrs', 'podDiscoveryPort'],
+      additionalProperties: false
     }
-  },
-  required: [],
-  additionalProperties: false
+  ]
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubiquitus-core",
   "description": "Actor model for Hubiquitus",
-  "version": "0.8.21",
+  "version": "0.8.22",
   "homepage": "http://www.hubiquitus.com",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fix hierarchical discovery.

Pods use a dedicated port for receiving 'remoteSearch' messages and use the source random discovery port to answer the remoteSearch request.
